### PR TITLE
Basic html escape in hugo for simple xss prevention

### DIFF
--- a/themes/hugo-type-theme/layouts/partials/post-comments.html
+++ b/themes/hugo-type-theme/layouts/partials/post-comments.html
@@ -12,9 +12,9 @@
         <div class="post-comment">
           <div class="post-comment-header">
             <img class="post-comment-avatar" src="https://www.gravatar.com/avatar/{{ .email }}?s=100">
-            <p class="post-comment-info"><strong>{{ .name }}</strong><br>{{ dateFormat "02/01/2006" .date }}</p>
+            <p class="post-comment-info"><strong>{{ .name | htmlEscape }}</strong><br>{{ dateFormat "02/01/2006" .date }}</p>
           </div>
-          {{ .body | markdownify }}
+          {{ .body | htmlEscape | markdownify }}
         </div>
       {{ end }}       
     {{ end }}


### PR DESCRIPTION
Putting unsanitized HTML entities into source code could lead to XSS by creating a malicious comment. The impact of XSS on static site is not as high as it could be in other cases, but it's worth noting. Probably staticman should do someting about XSS and entities encoding? 